### PR TITLE
Removing server tokens from Nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -12,6 +12,8 @@ http {
 
     output_buffers              1 32k;
     postpone_output             1460;
+    
+    server_tokens               off;
 
     sendfile                    on;
     tcp_nopush                  on;


### PR DESCRIPTION
Removes the version number from the response `Server` header, i.e. `Server: nginx/1.14.2`